### PR TITLE
feat: allow SCP commands to pass through for approval

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,10 +103,16 @@ export default function sshPermissionExtension(pi: ExtensionAPI, options?: SshPe
 			{ command: "echo ok", expectedBlocked: false },
 			{ command: "FOO=bar", expectedBlocked: false },
 			{ command: "echo hi > out.txt", expectedBlocked: false },
+			// SCP passes through (not blocked) - triggers bash permissions if enabled
+			{ command: "scp file user@host:/tmp", expectedBlocked: false },
+			{ command: "scp -r dir user@host:/tmp", expectedBlocked: false },
+			// SSH-family commands that are blocked
 			{ command: "ssh user@host", expectedBlocked: true },
 			{ command: "\\ssh user@host", expectedBlocked: true },
 			{ command: "sudo -- ssh user@host", expectedBlocked: true },
 			{ command: "\\sudo -- \\ssh user@host", expectedBlocked: true },
+			{ command: "sftp user@host", expectedBlocked: true },
+			{ command: "mosh user@host", expectedBlocked: true },
 			// Parse failures are fail-closed and should be blocked
 			{ command: "echo 'unterminated", expectedBlocked: true },
 			{ command: "echo ok &&", expectedBlocked: true },

--- a/src/policy/command-categories.yaml
+++ b/src/policy/command-categories.yaml
@@ -470,7 +470,7 @@ commands:
       - "wget POST *"
       - "wget *"
 
-  # Note: ssh, scp, sftp are handled by ssh_bash tool
+  # Note: ssh and sftp are blocked by SSH matcher; scp passes through to bash permissions
 
   # === TIER 7: PRIVILEGED ===
   sudo:

--- a/src/shell/analyzers/direct-ssh.ts
+++ b/src/shell/analyzers/direct-ssh.ts
@@ -5,7 +5,8 @@ import { resolveHeadFromLiterals } from "../parser/resolve-head.ts";
 import { SSH_MATCHER_WRAPPERS as WRAPPERS } from "../parser/wrappers.ts";
 import { legacyDirectSshFamilyMatchDetailed } from "../fallback/legacy-matcher.ts";
 
-const BLOCKED = new Set(["ssh", "scp", "sftp", "sshpass", "mosh"]);
+// SCP is intentionally NOT in BLOCKED - it passes through to bash permissions
+const BLOCKED = new Set(["ssh", "sftp", "sshpass", "mosh"]);
 
 function resolveExecutable(commandNode: any): { head: string; complete: boolean } {
 	if (!commandNode?.name) return { head: "", complete: true };

--- a/src/shell/fallback/legacy-matcher.ts
+++ b/src/shell/fallback/legacy-matcher.ts
@@ -2,7 +2,8 @@ import { stripHeredocBodiesForLegacyParsing } from "./heredoc.ts";
 import { isEnvAssignmentToken, normalizeExecutableToken } from "../parser/tokens.ts";
 import { SSH_MATCHER_WRAPPERS as DEFAULT_WRAPPERS, stepWrapper } from "../parser/wrappers.ts";
 
-const DEFAULT_BLOCKED = new Set(["ssh", "scp", "sftp", "sshpass", "mosh"]);
+// SCP is intentionally NOT blocked - it passes through to bash permissions
+const DEFAULT_BLOCKED = new Set(["ssh", "sftp", "sshpass", "mosh"]);
 
 export function legacySplitCommandSegments(command: string): string[] | null {
 	const out: string[] = [];
@@ -152,7 +153,8 @@ export function legacyDirectSshFamilyMatchDetailed(command: string): SshCheckRes
 	if (!segments) {
 		// Parse failure - check if SANITIZED command contains SSH keywords as a heuristic
 		// Using sanitized to avoid false positives from heredoc bodies
-		const hasSshKeyword = /\b(ssh|scp|sftp|sshpass|mosh)\b/.test(sanitized);
+		// Note: SCP is excluded - it passes through to bash permissions
+		const hasSshKeyword = /\b(ssh|sftp|sshpass|mosh)\b/.test(sanitized);
 		if (hasSshKeyword) {
 			return { blocked: true, reason: 'ssh_detected' };
 		}
@@ -162,7 +164,8 @@ export function legacyDirectSshFamilyMatchDetailed(command: string): SshCheckRes
 		const tokens = legacyTokenizeSegment(seg);
 		if (!tokens) {
 			// Check sanitized segment for SSH keywords
-			const hasSshKeyword = /\b(ssh|scp|sftp|sshpass|mosh)\b/.test(seg);
+			// Note: SCP is excluded - it passes through to bash permissions
+			const hasSshKeyword = /\b(ssh|sftp|sshpass|mosh)\b/.test(seg);
 			if (hasSshKeyword) {
 				return { blocked: true, reason: 'ssh_detected' };
 			}
@@ -171,7 +174,8 @@ export function legacyDirectSshFamilyMatchDetailed(command: string): SshCheckRes
 		const head = legacyResolveHead(tokens, DEFAULT_WRAPPERS);
 		if (head === null) {
 			// Check sanitized segment for SSH keywords
-			const hasSshKeyword = /\b(ssh|scp|sftp|sshpass|mosh)\b/.test(seg);
+			// Note: SCP is excluded - it passes through to bash permissions
+			const hasSshKeyword = /\b(ssh|sftp|sshpass|mosh)\b/.test(seg);
 			if (hasSshKeyword) {
 				return { blocked: true, reason: 'ssh_detected' };
 			}

--- a/tests/bash-noui-failclosed.test.ts
+++ b/tests/bash-noui-failclosed.test.ts
@@ -372,7 +372,7 @@ test("direct SSH blocking logs audit before bash permission check", async () => 
 	});
 
 	await handleToolCallGuard(
-		{ toolName: "bash", input: { command: "scp file.txt user@host:/tmp/" } },
+		{ toolName: "bash", input: { command: "ssh user@host" } },
 		runtime,
 	);
 

--- a/tests/bash-prompt-flow.test.ts
+++ b/tests/bash-prompt-flow.test.ts
@@ -190,3 +190,87 @@ test("integration: formatAllowPatternSummary works with guard patterns", async (
 		assert.ok(summary.includes("curl"), "Summary should include curl pattern");
 	}
 });
+
+// =============================================================================
+// SCP Passthrough - Bash Permissions Flow Tests
+// SCP commands pass through the SSH matcher and should trigger bash approval flow
+// =============================================================================
+
+test("SCP commands pass through guard to bash permissions when enabled", async () => {
+	let approvalChecked = false;
+	const runtime: GuardRuntime = {
+		guardHealthy: true,
+		matchDirectSsh: (cmd: string) => cmd.includes("ssh") && !cmd.includes("scp"), // SCP passes through
+		bashPermissions: { enabled: true },
+		hasUI: true,
+		checkBashApproval: async () => {
+			approvalChecked = true;
+			return { approved: false, scope: "none" };
+		},
+	};
+
+	// SCP command should pass SSH matcher and reach bash permissions
+	const result = await handleToolCallGuard(
+		{ toolName: "bash", input: { command: "scp file user@host:/tmp" } },
+		runtime,
+	);
+
+	// Approval check should have been invoked for SCP
+	assert.ok(approvalChecked, "SCP should trigger bash approval check");
+
+	// When not approved and UI available, should signal promptNeeded
+	assert.ok(result?.promptNeeded === true, "SCP should trigger promptNeeded for bash approval");
+});
+
+test("SCP commands blocked in no-UI mode when bash permissions enabled", async () => {
+	const runtime: GuardRuntime = {
+		guardHealthy: true,
+		matchDirectSsh: (cmd: string) => cmd.includes("ssh") && !cmd.includes("scp"), // SCP passes through
+		bashPermissions: { enabled: true },
+		hasUI: false,
+		checkBashApproval: async () => ({ approved: false, scope: "none" }),
+	};
+
+	const result = await handleToolCallGuard(
+		{ toolName: "bash", input: { command: "scp file user@host:/tmp" } },
+		runtime,
+	);
+
+	// In no-UI mode, SCP should be blocked (requires approval but can't prompt)
+	assert.ok(result?.block === true, "SCP should be blocked in no-UI mode");
+	assert.match(result?.reason || "", /not approved/i, "Should mention not approved");
+});
+
+test("SCP commands passthrough when bash permissions disabled", async () => {
+	const runtime: GuardRuntime = {
+		guardHealthy: true,
+		matchDirectSsh: (cmd: string) => cmd.includes("ssh") && !cmd.includes("scp"), // SCP passes through
+		bashPermissions: { enabled: false }, // Bash permissions disabled (default)
+	};
+
+	const result = await handleToolCallGuard(
+		{ toolName: "bash", input: { command: "scp file user@host:/tmp" } },
+		runtime,
+	);
+
+	// With bash permissions disabled, SCP should passthrough completely
+	assert.equal(result, undefined, "SCP should passthrough when bash permissions disabled");
+});
+
+test("SCP with approved bash permissions executes without prompt", async () => {
+	const runtime: GuardRuntime = {
+		guardHealthy: true,
+		matchDirectSsh: (cmd: string) => cmd.includes("ssh") && !cmd.includes("scp"), // SCP passes through
+		bashPermissions: { enabled: true },
+		hasUI: true,
+		checkBashApproval: async () => ({ approved: true, scope: "session" }),
+	};
+
+	const result = await handleToolCallGuard(
+		{ toolName: "bash", input: { command: "scp file user@host:/tmp" } },
+		runtime,
+	);
+
+	// Pre-approved SCP should passthrough
+	assert.equal(result, undefined, "Pre-approved SCP should passthrough");
+});

--- a/tests/scp-passthrough.test.ts
+++ b/tests/scp-passthrough.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isDirectSshFamilyCommand } from "../src/ssh/matcher.ts";
+import { legacyDirectSshFamilyMatchDetailed } from "../src/shell/fallback/legacy-matcher.ts";
+
+// =============================================================================
+// SCP Passthrough Tests
+// SCP commands should NOT be blocked by the direct SSH matcher.
+// They should pass through and trigger bash permissions approval when enabled.
+// =============================================================================
+
+test("SCP commands are NOT blocked by isDirectSshFamilyCommand", () => {
+	// SCP should pass through (not be blocked)
+	assert.equal(isDirectSshFamilyCommand("scp file user@host:/tmp"), false);
+	assert.equal(isDirectSshFamilyCommand("scp user@host:/remote/file ./local"), false);
+	assert.equal(isDirectSshFamilyCommand("scp -r directory user@host:/tmp"), false);
+	assert.equal(isDirectSshFamilyCommand("scp -P 22 file user@host:/tmp"), false);
+	assert.equal(isDirectSshFamilyCommand("scp -i key.pem file user@host:/tmp"), false);
+});
+
+test("SCP commands pass through legacy matcher (not blocked)", () => {
+	// SCP should pass through the legacy matcher too
+	const result1 = legacyDirectSshFamilyMatchDetailed("scp file user@host:/tmp");
+	assert.equal(result1.blocked, false, "scp should not be blocked");
+
+	const result2 = legacyDirectSshFamilyMatchDetailed("scp -r directory user@host:/tmp");
+	assert.equal(result2.blocked, false, "scp -r should not be blocked");
+
+	const result3 = legacyDirectSshFamilyMatchDetailed("scp user@host:/remote/file ./local");
+	assert.equal(result3.blocked, false, "scp download should not be blocked");
+});
+
+test("SCP passes through with env wrappers (not blocked)", () => {
+	// SCP through env wrapper should also pass through
+	assert.equal(isDirectSshFamilyCommand("env FOO=bar scp file user@host:/tmp"), false);
+	assert.equal(isDirectSshFamilyCommand("FOO=bar scp file user@host:/tmp"), false);
+});
+
+test("other SSH-family commands still blocked by isDirectSshFamilyCommand", () => {
+	// SSH, SFTP, SSHpass, Mosh should still be blocked
+	assert.equal(isDirectSshFamilyCommand("ssh user@host"), true);
+	assert.equal(isDirectSshFamilyCommand("sftp user@host"), true);
+	assert.equal(isDirectSshFamilyCommand("sshpass -p secret ssh user@host"), true);
+	assert.equal(isDirectSshFamilyCommand("mosh user@host"), true);
+});
+
+test("other SSH-family commands still blocked by legacy matcher", () => {
+	assert.equal(legacyDirectSshFamilyMatchDetailed("ssh user@host").blocked, true);
+	assert.equal(legacyDirectSshFamilyMatchDetailed("sftp user@host").blocked, true);
+	assert.equal(legacyDirectSshFamilyMatchDetailed("sshpass -p secret ssh user@host").blocked, true);
+	assert.equal(legacyDirectSshFamilyMatchDetailed("mosh user@host").blocked, true);
+});
+
+test("SCP in complex commands passes through", () => {
+	// SCP in various command structures should pass through
+	assert.equal(isDirectSshFamilyCommand("scp file user@host:/tmp && echo done"), false);
+	assert.equal(isDirectSshFamilyCommand("echo start; scp file user@host:/tmp"), false);
+	assert.equal(isDirectSshFamilyCommand("scp file user@host:/tmp || echo failed"), false);
+});
+
+test("SSH near SCP doesn't cause false positive", () => {
+	// Commands containing 'ssh' substring but not SSH commands should not be blocked
+	assert.equal(isDirectSshFamilyCommand("echo ssh && scp file user@host:/tmp"), false);
+});

--- a/tests/ssh-matcher.test.ts
+++ b/tests/ssh-matcher.test.ts
@@ -8,9 +8,10 @@ test("allows regular shell commands", () => {
 	assert.equal(isDirectSshFamilyCommand("FOO=bar"), false);
 });
 
-test("blocks direct ssh-family commands", () => {
+test("blocks direct ssh-family commands (except SCP which passes through)", () => {
 	assert.equal(isDirectSshFamilyCommand("ssh user@host"), true);
-	assert.equal(isDirectSshFamilyCommand("scp file user@host:/tmp"), true);
+	// SCP passes through to bash permissions - not blocked by SSH matcher
+	assert.equal(isDirectSshFamilyCommand("scp file user@host:/tmp"), false);
 	assert.equal(isDirectSshFamilyCommand("sftp user@host"), true);
 	assert.equal(isDirectSshFamilyCommand("mosh user@host"), true);
 	assert.equal(isDirectSshFamilyCommand("sshpass -p secret ssh user@host"), true);


### PR DESCRIPTION
## Problem

SCP commands like `scp file user@host:/path` were being blocked as "direct SSH-family commands" instead of being passed through to the bash permissions approval flow.

## Solution

- Remove `scp` from the direct SSH blocked commands
- SCP now passes through to bash permissions
- When bash permissions is enabled, users see an approval prompt with patterns like `scp *`
- Other SSH-family commands (`ssh`, `sftp`, `sshpass`, `mosh`) remain blocked

## Behavior

| Command | Before | After |
|---------|--------|-------|
| `scp file user@host:/path` | Blocked | Approval prompt |
| `ssh user@host` | Blocked | Blocked |
| `sftp user@host` | Blocked | Blocked |

## Testing

All 245 tests pass, including new tests for SCP passthrough behavior.